### PR TITLE
Add CBDDLP file format Support

### DIFF
--- a/frontend/src/components/UploadButton.tsx
+++ b/frontend/src/components/UploadButton.tsx
@@ -47,7 +47,7 @@ class UploadButton extends React.Component<
       <React.Fragment>
         <input
           ref={this.uploadButtonRef}
-          accept=".ctb"
+          accept=".cbddlp,.ctb"
           className={classes.input}
           id="upload-button"
           multiple

--- a/mariner/file_formats/cbddlp.py
+++ b/mariner/file_formats/cbddlp.py
@@ -1,0 +1,192 @@
+import pathlib
+import struct
+from dataclasses import dataclass
+from typing import List, Sequence, Tuple
+
+import png
+from typedstruct import LittleEndianStruct, StructType
+
+
+@dataclass(frozen=True)
+class CTBHeader(LittleEndianStruct):
+    magic: int = StructType.uint32()
+    version: int = StructType.uint32()
+    bed_size_x_mm: float = StructType.float32()
+    bed_size_y_mm: float = StructType.float32()
+    bed_size_z_mm: float = StructType.float32()
+    unknown_01: int = StructType.uint32()
+    unknown_02: int = StructType.uint32()
+    height_mm: float = StructType.float32()
+    layer_height_mm: float = StructType.float32()
+    layer_exposure: float = StructType.float32()
+    bottom_exposure: float = StructType.float32()
+    layer_off_time: float = StructType.float32()
+    bottom_count: int = StructType.uint32()
+    resolution_x: int = StructType.uint32()
+    resolution_y: int = StructType.uint32()
+    high_res_preview_offset: int = StructType.uint32()
+    layer_defs_offset: int = StructType.uint32()
+    layer_count: int = StructType.uint32()
+    low_res_preview_offset: int = StructType.uint32()
+    print_time: int = StructType.uint32()
+    projector: int = StructType.uint32()
+    param_offset: int = StructType.uint32()
+    param_size: int = StructType.uint32()
+    anti_alias_level: int = StructType.uint32()
+    light_pwm: int = StructType.uint16()
+    bottom_light_pwm: int = StructType.uint16()
+    encryption_seed: int = StructType.uint32()
+    slicer_offset: int = StructType.uint32()
+    slicer_size: int = StructType.uint32()
+
+
+@dataclass(frozen=True)
+class CTBSlicer(LittleEndianStruct):
+    skip_0: int = StructType.uint32()
+    skip_1: int = StructType.uint32()
+    skip_2: int = StructType.uint32()
+    skip_3: int = StructType.uint32()
+    skip_4: int = StructType.uint32()
+    skip_5: int = StructType.uint32()
+    skip_6: int = StructType.uint32()
+    machine_offset: int = StructType.uint32()
+    machine_size: int = StructType.uint32()
+    encryption_mode: int = StructType.uint32()
+    time_seconds: int = StructType.uint32()
+    unknown_01: int = StructType.uint32()
+    version_patch: int = StructType.unsigned_char()
+    version_minor: int = StructType.unsigned_char()
+    version_major: int = StructType.unsigned_char()
+    version_release: int = StructType.unsigned_char()
+    unknown_02: int = StructType.uint32()
+    unknown_03: int = StructType.uint32()
+    unknown_04: float = StructType.float32()
+    unknown_05: int = StructType.uint32()
+    unknown_06: int = StructType.uint32()
+    unknown_07: float = StructType.float32()
+
+
+@dataclass(frozen=True)
+class CTBLayerDef(LittleEndianStruct):
+    layer_height_mm: float = StructType.float32()
+    layer_exposure: float = StructType.float32()
+    layer_off_time: float = StructType.float32()
+    image_offset: int = StructType.uint32()
+    image_length: int = StructType.uint32()
+    unknown_01: int = StructType.uint32()
+    image_info_size: int = StructType.uint32()
+    unknown_02: int = StructType.uint32()
+    unknown_03: int = StructType.uint32()
+
+
+@dataclass(frozen=True)
+class CTBPreview(LittleEndianStruct):
+    resolution_x: int = StructType.uint32()
+    resolution_y: int = StructType.uint32()
+    image_offset: int = StructType.uint32()
+    image_length: int = StructType.uint32()
+
+
+REPEAT_RGB15_MASK: int = 1 << 5
+
+
+def _read_image(width: int, height: int, data: bytes) -> png.Image:
+    array: List[List[int]] = [[]]
+
+    (i, x) = (0, 0)
+    while i < len(data):
+        color16 = int(struct.unpack_from("<H", data, i)[0])
+        i += 2
+        repeat = 1
+        if color16 & REPEAT_RGB15_MASK:
+            repeat += int(struct.unpack_from("<H", data, i)[0]) & 0xFFF
+            i += 2
+
+        (r, g, b) = (
+            (color16 >> 0) & 0x1F,
+            (color16 >> 6) & 0x1F,
+            (color16 >> 11) & 0x1F,
+        )
+
+        while repeat > 0:
+            array[-1] += [r, g, b]
+            repeat -= 1
+
+            x += 1
+            if x == width:
+                x = 0
+                array.append([])
+
+    array.pop()
+
+    return png.from_array(array, "RGB;5")
+
+
+@dataclass(frozen=True)
+class CBDDLPFile:
+    filename: str
+    bed_size_mm: Tuple[float, float, float]
+    height_mm: float
+    layer_height_mm: float
+    layer_count: int
+    resolution: Tuple[int, int]
+    print_time_secs: int
+    end_byte_offset_by_layer: Sequence[int]
+    slicer_version: str
+    printer_name: str
+
+    @classmethod
+    def read(self, path: pathlib.Path) -> "CBDDLPFile":
+        with open(str(path), "rb") as file:
+            ctb_header = CTBHeader.unpack(file.read(CTBHeader.get_size()))
+
+            file.seek(ctb_header.slicer_offset)
+            ctb_slicer = CTBSlicer.unpack(file.read(CTBSlicer.get_size()))
+
+            file.seek(ctb_slicer.machine_offset)
+            printer_name = file.read(ctb_slicer.machine_size).decode()
+
+            end_byte_offset_by_layer = []
+            for layer in range(0, ctb_header.layer_count):
+                file.seek(ctb_header.layer_defs_offset + layer * CTBLayerDef.get_size())
+                layer_def = CTBLayerDef.unpack(file.read(CTBLayerDef.get_size()))
+                end_byte_offset_by_layer.append(
+                    layer_def.image_offset + layer_def.image_length
+                )
+
+            return CBDDLPFile(
+                filename=path.name,
+                bed_size_mm=(
+                    round(ctb_header.bed_size_x_mm, 4),
+                    round(ctb_header.bed_size_y_mm, 4),
+                    round(ctb_header.bed_size_z_mm, 4),
+                ),
+                height_mm=ctb_header.height_mm,
+                layer_height_mm=ctb_header.layer_height_mm,
+                layer_count=ctb_header.layer_count,
+                resolution=(ctb_header.resolution_x, ctb_header.resolution_y),
+                print_time_secs=ctb_header.print_time,
+                end_byte_offset_by_layer=end_byte_offset_by_layer,
+                slicer_version=".".join(
+                    [
+                        str(ctb_slicer.version_release),
+                        str(ctb_slicer.version_major),
+                        str(ctb_slicer.version_minor),
+                        str(ctb_slicer.version_patch),
+                    ]
+                ),
+                printer_name=printer_name,
+            )
+
+    @classmethod
+    def read_preview(cls, path: pathlib.Path) -> png.Image:
+        with open(str(path), "rb") as file:
+            ctb_header = CTBHeader.unpack(file.read(CTBHeader.get_size()))
+
+            file.seek(ctb_header.high_res_preview_offset)
+            preview = CTBPreview.unpack(file.read(CTBPreview.get_size()))
+
+            file.seek(preview.image_offset)
+            data = file.read(preview.image_length)
+
+            return _read_image(preview.resolution_x, preview.resolution_y, data)

--- a/mariner/server/__init__.py
+++ b/mariner/server/__init__.py
@@ -10,7 +10,9 @@ from mariner.server.api import api as api_blueprint
 from mariner.server.app import app as flask_app
 from mariner.server.utils import (
     read_cached_ctb_file,
-    read_cached_preview,
+    read_cached_cbddlp_file,
+    read_cached_ctb_preview,
+    read_cached_cbddlp_preview,
 )
 
 

--- a/mariner/server/__init__.py
+++ b/mariner/server/__init__.py
@@ -27,10 +27,12 @@ def index() -> str:
 class CacheBootstrapper(multiprocessing.Process):
     def run(self) -> None:
         os.nice(5)
+        for file in FILES_DIRECTORY.rglob("*.cbddlp"):
+            read_cached_cbddlp_file(file.absolute())
+            read_cached_cbddlp_preview(file.absolute())
         for file in FILES_DIRECTORY.rglob("*.ctb"):
             read_cached_ctb_file(file.absolute())
-        for file in FILES_DIRECTORY.rglob("*.ctb"):
-            read_cached_preview(file.absolute())
+            read_cached_ctb_preview(file.absolute())
 
 
 def main() -> None:

--- a/mariner/server/api.py
+++ b/mariner/server/api.py
@@ -17,6 +17,7 @@ from werkzeug.utils import secure_filename
 from mariner.config import FILES_DIRECTORY
 from mariner.exceptions import MarinerException
 from mariner.file_formats.ctb import CTBFile
+from mariner.file_formats.cbddlp import CBDDLPFile
 from mariner.mars import ElegooMars, PrinterState
 from mariner.server.utils import read_cached_cbddlp_file, read_cached_ctb_file, read_cached_cbddlp_preview, read_cached_ctb_preview
 
@@ -161,7 +162,6 @@ def file_details() -> str:
 def upload_file() -> str:
     file = request.files.get("file")
     file_extension = os.path.splitext(file.filename)[1]
-    print("file_extension: " + file_extension)
     if file is None or file.filename == "":
         abort(400)
     if file_extension not in [".cbddlp", ".ctb"]:

--- a/mariner/server/utils.py
+++ b/mariner/server/utils.py
@@ -24,7 +24,15 @@ def read_cached_cbddlp_file(filename: str) -> CBDDLPFile:
     return CBDDLPFile.read(FILES_DIRECTORY / filename)
 
 @cache.memoize(timeout=0)
-def read_cached_preview(filename: str) -> bytes:
+def read_cached_cbddlp_preview(filename: str) -> bytes:
+    assert os.path.isabs(filename)
+    bytes = io.BytesIO()
+    preview_image: png.Image = CBDDLPFile.read_preview(FILES_DIRECTORY / filename)
+    preview_image.write(bytes)
+    return bytes.getvalue()
+
+@cache.memoize(timeout=0)
+def read_cached_ctb_preview(filename: str) -> bytes:
     assert os.path.isabs(filename)
     bytes = io.BytesIO()
     preview_image: png.Image = CBDDLPFile.read_preview(FILES_DIRECTORY / filename)

--- a/mariner/server/utils.py
+++ b/mariner/server/utils.py
@@ -6,6 +6,7 @@ from flask_caching import Cache
 
 from mariner.config import FILES_DIRECTORY
 from mariner.file_formats.ctb import CTBFile
+from mariner.file_formats.cbddlp import CBDDLPFile
 from mariner.server.app import app
 
 
@@ -17,11 +18,15 @@ def read_cached_ctb_file(filename: str) -> CTBFile:
     assert os.path.isabs(filename)
     return CTBFile.read(FILES_DIRECTORY / filename)
 
+@cache.memoize(timeout=0)
+def read_cached_cbddlp_file(filename: str) -> CBDDLPFile:
+    assert os.path.isabs(filename)
+    return CBDDLPFile.read(FILES_DIRECTORY / filename)
 
 @cache.memoize(timeout=0)
 def read_cached_preview(filename: str) -> bytes:
     assert os.path.isabs(filename)
     bytes = io.BytesIO()
-    preview_image: png.Image = CTBFile.read_preview(FILES_DIRECTORY / filename)
+    preview_image: png.Image = CBDDLPFile.read_preview(FILES_DIRECTORY / filename)
     preview_image.write(bytes)
     return bytes.getvalue()


### PR DESCRIPTION
Reasoning for this code:

One of my Mars Printers is running a B board for which I haven't been able to find a working firmware supporting CTB:

- Elegoo Mars - Red and Black
- mainboard includes ethernet port (though I don't use it) - version B board?
- System: ChiTu L 5.5 Series
- Version: V4.2.20.3_LCDM /1440x2560 /F2.9

While searching and also waiting for feedback from Elegoo Support on this, I decided to produce these changes, which have been tested already on my Mars using an FTDI usb<>serial adapter and my development PC running GNU/Linux.

With these changes I was able to successfully load CBDDLP files for preview, start a print, pause>resume a print and stop as well.

The **stop** action produced an unexpected result, though: the LCD touch screen goes to the main view right away, while the fan, LEDs and screen mask all remain on.
To be able to perform a proper print stop action, I found that for this Mars printer of mine, this sequence works fine:

**Print > Pause > (let it pause the print) > Stop**

Finally, I hope to find a working firmware version for this machine that will successfully use the CTB file format, but until then, this works fine.