### PR TITLE
Added Mars 2 to supported Printers

### DIFF
--- a/docs/supported-printers.rst
+++ b/docs/supported-printers.rst
@@ -6,6 +6,7 @@ community:
 
 - Elegoo Mars
 - Elegoo Mars Pro
+- Elegoo Mars 2
 - Elegoo Mars 2 Pro
 - Elegoo Saturn
 - Phrozen Sonic Mighty 4K


### PR DESCRIPTION
I have set up my Elegoo Mars 2 with no issues and have verified it to be compatible. The hardware between mars 2 and pro is the same minus the Carbon filter and metal Vat.