### PR TITLE
Add support for .photon files

### DIFF
--- a/mariner/file_formats/ctb.py
+++ b/mariner/file_formats/ctb.py
@@ -41,6 +41,23 @@ class CTBHeader(LittleEndianStruct):
     slicer_offset: int = StructType.uint32()
     slicer_size: int = StructType.uint32()
 
+@dataclass(frozen=True)
+class CTBParam(LittleEndianStruct):
+    bottom_lift_height: int = StructType.float32() # 00:
+    bottom_lift_speed: int = StructType.float32() # 04:
+    lift_height: int = StructType.float32() # 08:
+    lift_speed: int = StructType.float32() # 0c:
+    retract_speed: int = StructType.float32() # 10:
+    volume_ml: int = StructType.float32() # 14: Volume of resin in ml
+    weight_gr: int = StructType.float32() # 18: resin weight in grams
+    cost_dollars: int = StructType.float32() # 1c: slicers estimated resin cost in USD
+    bottom_lift_off_time: int = StructType.float32() # 20
+    light_off_time: int = StructType.float32() # 24:
+    bottom_layer_count: int = StructType.uint32() # 28:
+    unknown_01: int = StructType.uint32() # 2c:
+    unknown_02: int = StructType.float32() # 30:
+    unknown_03: int = StructType.uint32() # 34:
+    unknown_04: int = StructType.uint32() # 38:
 
 @dataclass(frozen=True)
 class CTBSlicer(LittleEndianStruct):

--- a/mariner/file_formats/photon.py
+++ b/mariner/file_formats/photon.py
@@ -11,75 +11,65 @@ from mariner.file_formats import SlicedModelFile
 
 @dataclass(frozen=True)
 class PhotonHeader(LittleEndianStruct):
-    magic: int = StructType.uint32() #Always 0x12FD0019
-    version: int = StructType.uint32()
-    bed_size_x_mm: float = StructType.float32()
+    magic: int = StructType.uint32() # 00: Always 0x12FD0019
+    version: int = StructType.uint32() # 04: Always 0x01
+    bed_size_x_mm: float = StructType.float32() # 08:
     bed_size_y_mm: float = StructType.float32()
     bed_size_z_mm: float = StructType.float32()
-    unknown_01: int = StructType.uint32()
+    unknown_01: int = StructType.uint32() # 14
     unknown_02: int = StructType.uint32()
-    height_mm: float = StructType.float32()
-    layer_height_mm: float = StructType.float32()
-    layer_exposure: float = StructType.float32()
-    bottom_exposure: float = StructType.float32()
-    layer_off_time: float = StructType.float32()
-    bottom_count: int = StructType.uint32()
-    resolution_x: int = StructType.uint32()
-    resolution_y: int = StructType.uint32()
-    high_res_preview_offset: int = StructType.uint32()
-    layer_defs_offset: int = StructType.uint32()
-    layer_count: int = StructType.uint32()
-    low_res_preview_offset: int = StructType.uint32()
-    print_time: int = StructType.uint32()
-    projector: int = StructType.uint32()
-    param_offset: int = StructType.uint32()
-    param_size: int = StructType.uint32()
-    anti_alias_level: int = StructType.uint32()
-    light_pwm: int = StructType.uint16()
-    bottom_light_pwm: int = StructType.uint16()
-    encryption_seed: int = StructType.uint32()
-    slicer_offset: int = StructType.uint32()
-    slicer_size: int = StructType.uint32()
-
-
-@dataclass(frozen=True)
-class PhotonSlicer(LittleEndianStruct):
-    skip_0: int = StructType.uint32()
-    skip_1: int = StructType.uint32()
-    skip_2: int = StructType.uint32()
-    skip_3: int = StructType.uint32()
-    skip_4: int = StructType.uint32()
-    skip_5: int = StructType.uint32()
-    skip_6: int = StructType.uint32()
-    machine_offset: int = StructType.uint32()
-    machine_size: int = StructType.uint32()
-    encryption_mode: int = StructType.uint32()
-    time_seconds: int = StructType.uint32()
-    unknown_01: int = StructType.uint32()
-    version_patch: int = StructType.unsigned_char()
-    version_minor: int = StructType.unsigned_char()
-    version_major: int = StructType.unsigned_char()
-    version_release: int = StructType.unsigned_char()
-    unknown_02: int = StructType.uint32()
-    unknown_03: int = StructType.uint32()
-    unknown_04: float = StructType.float32()
+    unknown_03: float = StructType.uint32()
+    layer_height_mm: float = StructType.float32() # 20:
+    layer_exposure: float = StructType.float32() # 24: Layer exposure(in seconds)
+    bottom_exposure: float = StructType.float32() # 28: Bottom layers exposure(in seconds)
+    layer_off_time: float = StructType.float32() # 2c: Layer off time(in seconds)
+    bottom_count: int = StructType.uint32() # 30: Number of bottom layers
+    resolution_x: int = StructType.uint32() # 34:
+    resolution_y: int = StructType.uint32() # 38:
+    high_res_preview_offset: int = StructType.uint32() # 3c: Offset of the high-res preview
+    layer_defs_offset: int = StructType.uint32() # 40: Offset of the layer definitions
+    layer_count: int = StructType.uint32() #44:
+    low_res_preview_offset: int = StructType.uint32() # 48: Offset of the low-rew preview
+    print_time: int = StructType.uint32() # 4c: In seconds
+    projector: int = StructType.uint32() # 50: 0 = CAST, 1 = LCD_X_MIRROR
+    param_offset: int = StructType.uint32() # 54:
+    param_size: int = StructType.uint32() # 58:
+    anti_alias_level: int = StructType.uint32() # 5c:
+    light_pwm: int = StructType.uint16() # 60:
+    bottom_light_pwm: int = StructType.uint16() # 62:
+    unknown_04: int = StructType.uint32() # 64:
     unknown_05: int = StructType.uint32()
     unknown_06: int = StructType.uint32()
-    unknown_07: float = StructType.float32()
 
+@dataclass(frozen=True)
+class PhotonParam(LittleEndianStruct):
+    bottom_lift_height: int = StructType.float32() # 00:
+    bottom_lift_speed: int = StructType.float32() # 04:
+    lift_height: int = StructType.float32() # 08:
+    lift_speed: int = StructType.float32() # 0c:
+    retract_speed: int = StructType.float32() # 10:
+    volume_ml: int = StructType.float32() # 14: Volume of resin in ml
+    weight_gr: int = StructType.float32() # 18: resin weight in grams
+    cost_dollars: int = StructType.float32() # 1c: slicers estimated resin cost in USD
+    bottom_lift_off_time: int = StructType.float32() # 20
+    light_off_time: int = StructType.float32() # 24:
+    bottom_layer_count: int = StructType.uint32() # 28:
+    unknown_01: int = StructType.uint32() # 2c:
+    unknown_02: int = StructType.uint32() # 30:
+    unknown_03: int = StructType.uint32() # 34:
+    unknown_04: int = StructType.uint32() # 38:
 
 @dataclass(frozen=True)
 class PhotonLayerDef(LittleEndianStruct):
-    layer_height_mm: float = StructType.float32()
-    layer_exposure: float = StructType.float32()
-    layer_off_time: float = StructType.float32()
-    image_offset: int = StructType.uint32()
-    image_length: int = StructType.uint32()
-    unknown_01: int = StructType.uint32()
-    image_info_size: int = StructType.uint32()
-    unknown_02: int = StructType.uint32()
-    unknown_03: int = StructType.uint32()
-
+    layer_height_mm: float = StructType.float32() # 00:
+    layer_exposure: float = StructType.float32() # 04:
+    layer_off_time: float = StructType.float32() # 08:
+    image_offset: int = StructType.uint32() # 0c:
+    image_length: int = StructType.uint32() # 10:
+    unknown_01: int = StructType.uint32() # 14:
+    unknown_02: int = StructType.uint32() # 18:
+    unknown_03: int = StructType.uint32() # 1c:
+    unknown_04: int = StructType.uint32() # 20:
 
 @dataclass(frozen=True)
 class PhotonPreview(LittleEndianStruct):
@@ -87,6 +77,10 @@ class PhotonPreview(LittleEndianStruct):
     resolution_y: int = StructType.uint32()
     image_offset: int = StructType.uint32()
     image_length: int = StructType.uint32()
+    unknown_01: int = StructType.uint32()
+    unknown_02: int = StructType.uint32()
+    unknown_03: int = StructType.uint32()
+    unknown_04: int = StructType.uint32()
 
 
 REPEAT_RGB15_MASK: int = 1 << 5
@@ -131,12 +125,6 @@ class PhotonFile(SlicedModelFile):
         with open(str(path), "rb") as file:
             photon_header = PhotonHeader.unpack(file.read(PhotonHeader.get_size()))
 
-            file.seek(photon_header.slicer_offset)
-            photon_slicer = PhotonSlicer.unpack(file.read(PhotonSlicer.get_size()))
-
-            file.seek(photon_slicer.machine_offset)
-            printer_name = file.read(photon_slicer.machine_size).decode()
-
             end_byte_offset_by_layer = []
             for layer in range(0, photon_header.layer_count):
                 file.seek(photon_header.layer_defs_offset + layer * PhotonLayerDef.get_size())
@@ -152,21 +140,14 @@ class PhotonFile(SlicedModelFile):
                     round(photon_header.bed_size_y_mm, 4),
                     round(photon_header.bed_size_z_mm, 4),
                 ),
-                height_mm=photon_header.height_mm,
+                height_mm=photon_header.layer_height_mm*photon_header.layer_count,
                 layer_height_mm=photon_header.layer_height_mm,
                 layer_count=photon_header.layer_count,
                 resolution=(photon_header.resolution_x, photon_header.resolution_y),
                 print_time_secs=photon_header.print_time,
                 end_byte_offset_by_layer=end_byte_offset_by_layer,
-                slicer_version=".".join(
-                    [
-                        str(photon_slicer.version_release),
-                        str(photon_slicer.version_major),
-                        str(photon_slicer.version_minor),
-                        str(photon_slicer.version_patch),
-                    ]
-                ),
-                printer_name=printer_name,
+                slicer_version="1.6.5.1",
+                printer_name="ANYCUBIC PHOTON",
             )
 
     @classmethod

--- a/mariner/file_formats/photon.py
+++ b/mariner/file_formats/photon.py
@@ -1,0 +1,183 @@
+import pathlib
+import struct
+from dataclasses import dataclass
+from typing import List
+
+import png
+from typedstruct import LittleEndianStruct, StructType
+
+from mariner.file_formats import SlicedModelFile
+
+
+@dataclass(frozen=True)
+class PhotonHeader(LittleEndianStruct):
+    magic: int = StructType.uint32() #Always 0x12FD0019
+    version: int = StructType.uint32()
+    bed_size_x_mm: float = StructType.float32()
+    bed_size_y_mm: float = StructType.float32()
+    bed_size_z_mm: float = StructType.float32()
+    unknown_01: int = StructType.uint32()
+    unknown_02: int = StructType.uint32()
+    height_mm: float = StructType.float32()
+    layer_height_mm: float = StructType.float32()
+    layer_exposure: float = StructType.float32()
+    bottom_exposure: float = StructType.float32()
+    layer_off_time: float = StructType.float32()
+    bottom_count: int = StructType.uint32()
+    resolution_x: int = StructType.uint32()
+    resolution_y: int = StructType.uint32()
+    high_res_preview_offset: int = StructType.uint32()
+    layer_defs_offset: int = StructType.uint32()
+    layer_count: int = StructType.uint32()
+    low_res_preview_offset: int = StructType.uint32()
+    print_time: int = StructType.uint32()
+    projector: int = StructType.uint32()
+    param_offset: int = StructType.uint32()
+    param_size: int = StructType.uint32()
+    anti_alias_level: int = StructType.uint32()
+    light_pwm: int = StructType.uint16()
+    bottom_light_pwm: int = StructType.uint16()
+    encryption_seed: int = StructType.uint32()
+    slicer_offset: int = StructType.uint32()
+    slicer_size: int = StructType.uint32()
+
+
+@dataclass(frozen=True)
+class PhotonSlicer(LittleEndianStruct):
+    skip_0: int = StructType.uint32()
+    skip_1: int = StructType.uint32()
+    skip_2: int = StructType.uint32()
+    skip_3: int = StructType.uint32()
+    skip_4: int = StructType.uint32()
+    skip_5: int = StructType.uint32()
+    skip_6: int = StructType.uint32()
+    machine_offset: int = StructType.uint32()
+    machine_size: int = StructType.uint32()
+    encryption_mode: int = StructType.uint32()
+    time_seconds: int = StructType.uint32()
+    unknown_01: int = StructType.uint32()
+    version_patch: int = StructType.unsigned_char()
+    version_minor: int = StructType.unsigned_char()
+    version_major: int = StructType.unsigned_char()
+    version_release: int = StructType.unsigned_char()
+    unknown_02: int = StructType.uint32()
+    unknown_03: int = StructType.uint32()
+    unknown_04: float = StructType.float32()
+    unknown_05: int = StructType.uint32()
+    unknown_06: int = StructType.uint32()
+    unknown_07: float = StructType.float32()
+
+
+@dataclass(frozen=True)
+class PhotonLayerDef(LittleEndianStruct):
+    layer_height_mm: float = StructType.float32()
+    layer_exposure: float = StructType.float32()
+    layer_off_time: float = StructType.float32()
+    image_offset: int = StructType.uint32()
+    image_length: int = StructType.uint32()
+    unknown_01: int = StructType.uint32()
+    image_info_size: int = StructType.uint32()
+    unknown_02: int = StructType.uint32()
+    unknown_03: int = StructType.uint32()
+
+
+@dataclass(frozen=True)
+class PhotonPreview(LittleEndianStruct):
+    resolution_x: int = StructType.uint32()
+    resolution_y: int = StructType.uint32()
+    image_offset: int = StructType.uint32()
+    image_length: int = StructType.uint32()
+
+
+REPEAT_RGB15_MASK: int = 1 << 5
+
+
+def _read_image(width: int, height: int, data: bytes) -> png.Image:
+    array: List[List[int]] = [[]]
+
+    (i, x) = (0, 0)
+    while i < len(data):
+        color16 = int(struct.unpack_from("<H", data, i)[0])
+        i += 2
+        repeat = 1
+        if color16 & REPEAT_RGB15_MASK:
+            repeat += int(struct.unpack_from("<H", data, i)[0]) & 0xFFF
+            i += 2
+
+        (r, g, b) = (
+            (color16 >> 0) & 0x1F,
+            (color16 >> 6) & 0x1F,
+            (color16 >> 11) & 0x1F,
+        )
+
+        while repeat > 0:
+            array[-1] += [r, g, b]
+            repeat -= 1
+
+            x += 1
+            if x == width:
+                x = 0
+                array.append([])
+
+    array.pop()
+
+    return png.from_array(array, "RGB;5")
+
+
+@dataclass(frozen=True)
+class PhotonFile(SlicedModelFile):
+    @classmethod
+    def read(self, path: pathlib.Path) -> "PhotonFile":
+        with open(str(path), "rb") as file:
+            photon_header = PhotonHeader.unpack(file.read(PhotonHeader.get_size()))
+
+            file.seek(photon_header.slicer_offset)
+            photon_slicer = PhotonSlicer.unpack(file.read(PhotonSlicer.get_size()))
+
+            file.seek(photon_slicer.machine_offset)
+            printer_name = file.read(photon_slicer.machine_size).decode()
+
+            end_byte_offset_by_layer = []
+            for layer in range(0, photon_header.layer_count):
+                file.seek(photon_header.layer_defs_offset + layer * PhotonLayerDef.get_size())
+                layer_def = PhotonLayerDef.unpack(file.read(PhotonLayerDef.get_size()))
+                end_byte_offset_by_layer.append(
+                    layer_def.image_offset + layer_def.image_length
+                )
+
+            return PhotonFile(
+                filename=path.name,
+                bed_size_mm=(
+                    round(photon_header.bed_size_x_mm, 4),
+                    round(photon_header.bed_size_y_mm, 4),
+                    round(photon_header.bed_size_z_mm, 4),
+                ),
+                height_mm=photon_header.height_mm,
+                layer_height_mm=photon_header.layer_height_mm,
+                layer_count=photon_header.layer_count,
+                resolution=(photon_header.resolution_x, photon_header.resolution_y),
+                print_time_secs=photon_header.print_time,
+                end_byte_offset_by_layer=end_byte_offset_by_layer,
+                slicer_version=".".join(
+                    [
+                        str(photon_slicer.version_release),
+                        str(photon_slicer.version_major),
+                        str(photon_slicer.version_minor),
+                        str(photon_slicer.version_patch),
+                    ]
+                ),
+                printer_name=printer_name,
+            )
+
+    @classmethod
+    def read_preview(cls, path: pathlib.Path) -> png.Image:
+        with open(str(path), "rb") as file:
+            photon_header = PhotonHeader.unpack(file.read(PhotonHeader.get_size()))
+
+            file.seek(photon_header.high_res_preview_offset)
+            preview = PhotonPreview.unpack(file.read(PhotonPreview.get_size()))
+
+            file.seek(preview.image_offset)
+            data = file.read(preview.image_length)
+
+            return _read_image(preview.resolution_x, preview.resolution_y, data)

--- a/mariner/file_formats/tests/test_photon.py
+++ b/mariner/file_formats/tests/test_photon.py
@@ -17,17 +17,18 @@ class PhotonFileTest(TestCase):
         expect(photon_file.bed_size_mm).to_equal((68.04, 120.96, 150.0))
         expect(photon_file.height_mm).close_to(17.0, max_delta=1e-9)
         expect(photon_file.layer_height_mm).close_to(0.05, max_delta=1e-9)
-        expect(photon_file.layer_count).to_equal(341)
+        expect(photon_file.layer_count).to_equal(340)
         expect(photon_file.resolution).to_equal((1440, 2560))
         expect(photon_file.print_time_secs).to_equal(5171)
         expect(photon_file.end_byte_offset_by_layer[:5]).to_equal(
-            [26272, 28057, 29842, 31627, 33412]
+            [54492, 85084, 115763, 146232, 176680]
         )
         expect(photon_file.end_byte_offset_by_layer[-5:]).to_equal(
-            [822027, 824704, 827383, 830061, 832745]
+            [10132550, 10162753, 10192956, 10223159, 10253362]
         )
-        expect(photon_file.slicer_version).to_equal("1.6.5.1")
-        expect(photon_file.printer_name).to_equal("ANYCUBIC PHOTON")
+
+        expect(photon_file.slicer_version).to_equal("1.7.0.0")
+        expect(photon_file.printer_name).to_equal("AnyCubic Photon")
 
     def test_preview_rendering(self) -> None:
         path = pathlib.Path(__file__).parent.absolute() / "stairs.photon"
@@ -38,6 +39,6 @@ class PhotonFileTest(TestCase):
         expect(preview_image.info["height"]).to_equal(300)
         expect(preview_image.info["bitdepth"]).to_equal(5)
         expect(preview_image.info["alpha"]).is_false()
-        #expect(hashlib.md5(bytes.getvalue()).hexdigest()).to_equal(
-        #    "ca98c806d42898ba70626e556f714928"
-        #)
+        expect(hashlib.md5(bytes.getvalue()).hexdigest()).to_equal(
+            "44e523ed707f3dfcad8071fe46c537f3"
+        )

--- a/mariner/file_formats/tests/test_photon.py
+++ b/mariner/file_formats/tests/test_photon.py
@@ -1,0 +1,43 @@
+import hashlib
+import io
+import pathlib
+from unittest import TestCase
+
+import png
+from pyexpect import expect
+
+from mariner.file_formats.photon import PhotonFile
+
+
+class PhotonFileTest(TestCase):
+    def test_loading_photon_file(self) -> None:
+        path = pathlib.Path(__file__).parent.absolute() / "stairs.photon"
+        photon_file = PhotonFile.read(path)
+        expect(photon_file.filename).to_equal("stairs.photon")
+        expect(photon_file.bed_size_mm).to_equal((68.04, 120.96, 150.0))
+        expect(photon_file.height_mm).close_to(17.0, max_delta=1e-9)
+        expect(photon_file.layer_height_mm).close_to(0.05, max_delta=1e-9)
+        expect(photon_file.layer_count).to_equal(341)
+        expect(photon_file.resolution).to_equal((1440, 2560))
+        expect(photon_file.print_time_secs).to_equal(5171)
+        expect(photon_file.end_byte_offset_by_layer[:5]).to_equal(
+            [26272, 28057, 29842, 31627, 33412]
+        )
+        expect(photon_file.end_byte_offset_by_layer[-5:]).to_equal(
+            [822027, 824704, 827383, 830061, 832745]
+        )
+        expect(photon_file.slicer_version).to_equal("1.6.5.1")
+        expect(photon_file.printer_name).to_equal("ANYCUBIC PHOTON")
+
+    def test_preview_rendering(self) -> None:
+        path = pathlib.Path(__file__).parent.absolute() / "stairs.photon"
+        bytes = io.BytesIO()
+        preview_image: png.Image = PhotonFile.read_preview(path)
+        preview_image.write(bytes)
+        expect(preview_image.info["width"]).to_equal(400)
+        expect(preview_image.info["height"]).to_equal(300)
+        expect(preview_image.info["bitdepth"]).to_equal(5)
+        expect(preview_image.info["alpha"]).is_false()
+        #expect(hashlib.md5(bytes.getvalue()).hexdigest()).to_equal(
+        #    "ca98c806d42898ba70626e556f714928"
+        #)

--- a/mariner/file_formats/utils.py
+++ b/mariner/file_formats/utils.py
@@ -5,12 +5,14 @@ from mariner.file_formats import SlicedModelFile
 from mariner.file_formats.ctb import CTBFile
 from mariner.file_formats.cbddlp import CBDDLPFile
 from mariner.file_formats.fdg import FDGFile
+from mariner.file_formats.photon import PhotonFile
 
 
 EXTENSION_TO_FILE_FORMAT: Mapping[str, Type[SlicedModelFile]] = {
     ".ctb": CTBFile,
     ".cbddlp": CBDDLPFile,
     ".fdg": FDGFile,
+    ".photon": PhotonFile,uti	
 }
 
 


### PR DESCRIPTION
Anycubic photon uses same baud rate as other chituboard based printers. Added .photon file format so support for Anycubic photon can be added eventually. The file format data in https://github.com/ezrec/uv3dp and https://github.com/Andoryuuta/photon/blob/master/photon.go was used as a reference. I'm also using your file format code for my chituboard octoprint plugin(preliminary version will be released soon).