### PR TITLE
Add upload progress indicator

### DIFF
--- a/frontend/src/api.tsx
+++ b/frontend/src/api.tsx
@@ -85,13 +85,17 @@ export class API {
     }
   }
 
-  async uploadFile(file: File): Promise<CommandAPIResponse | undefined> {
+  async uploadFile(
+    file: File,
+    progress: (event: ProgressEvent) => void
+  ): Promise<CommandAPIResponse | undefined> {
     try {
       const formData = new FormData();
       formData.append("file", file);
       const response: AxiosResponse<CommandAPIResponse> = await axios.post(
         "api/upload_file",
-        formData
+        formData,
+        { onUploadProgress: progress }
       );
       return response.data;
     } catch (error) {


### PR DESCRIPTION
(new PR due to my bad branching habits, sorry for churn)

Uploads are slow on a RPi Zero, so it's helpful to know that it hasn't just totally stalled.
Also, the linters noted in the contributing docs reformatted `index.tsx`.

Screenshot of progress upload attached!

<img width="144" alt="Screen Shot 2021-07-07 at 8 45 53 PM" src="https://user-images.githubusercontent.com/1189703/124860143-03e61280-df66-11eb-9321-0987309c039f.png">

