### PR TITLE
dh-systemd has been removed from Bullseye.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,7 @@ FROM balenalib/raspberry-pi-debian:latest
 
 RUN apt-get update && apt-get -y upgrade && apt-get update
 RUN apt-get -y install sudo dpkg-dev debhelper dh-virtualenv \
-  dh-systemd python3 python3-venv
+  python3 python3-venv
 
 RUN apt-get -y install libxslt-dev libxml2-dev
 RUN apt-get -y install build-essential libssl-dev libffi-dev python3-dev


### PR DESCRIPTION
As per https://bugs.debian.org/822670, the dh-systemd package has been merged with the main debhelper package since version 9.20160709

For some time, a transitional dh-systemd package existed which simply depended on debhelper. However, this was removed from bullseye.

The fix should be as simple as depending on debhelper (>= 9.20160709), which available on all supported Debian releases and all supported Ubuntu releases except for xenial.