### PR TITLE
Use latest non-beta Black

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -35,7 +35,7 @@ pytz = ">=2015.7"
 
 [[package]]
 name = "black"
-version = "20.8b1"
+version = "22.1.0"
 description = "The uncompromising code formatter."
 category = "dev"
 optional = false


### PR DESCRIPTION
Hopefully get rid of this issue in the build:

ImportError: /home/runner/.virtualenvs/.venv/lib/python3.9/site-packages/typed_ast/_ast3.cpython-39-x86_64-linux-gnu.so: undefined symbol: _PyUnicode_DecodeUnicodeEscape