### PR TITLE
Update Black to non-beta to prevent build failures

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -25,7 +25,7 @@ waitress = "2.0.0"
 whitenoise = "5.2.0"
 
 [tool.poetry.dev-dependencies]
-black = "20.8b1"
+black = "22.1.0"
 flake8 = "3.9.2"
 freezegun = "1.1.0"
 green = "3.2.6"


### PR DESCRIPTION
Updated to fix this:

ImportError: /home/runner/.virtualenvs/.venv/lib/python3.9/site-packages/typed_ast/_ast3.cpython-39-x86_64-linux-gnu.so: undefined symbol: _PyUnicode_DecodeUnicodeEscape